### PR TITLE
Primary keys can be zero value, they should not be nil that's all

### DIFF
--- a/model.go
+++ b/model.go
@@ -198,7 +198,7 @@ func genericSaveMultiplePK(table *Table, m Model, keys map[string]int) error {
 	reflectedModel := tools.GetNonPtrValue(m)
 	for fieldName, idx := range keys {
 		field := reflectedModel.Field(idx)
-		if tools.IsZeroValue(field) {
+		if tools.IsNil(field) {
 			return errors.Errorf("Cannot save this model: one Primary Key has zero value")
 		}
 		filterIdx := table.FilterFieldIndex(fieldName)

--- a/tools/reflect.go
+++ b/tools/reflect.go
@@ -43,3 +43,12 @@ func IsZeroValue(v reflect.Value) bool {
 		return true
 	}
 }
+
+// IsNil returns true if given value is nil
+func IsNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Func, reflect.Map, reflect.Slice, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}


### PR DESCRIPTION
The unit test example is a bit wrong, but we could have two PK, "foo_id" and "order" on a table, and having order=0 should be valid. Let's remove this constraint, and simply make sure we are not trying to save a nil value inside a primary key