### PR TITLE
Add Distinct option for SelectBuilder

### DIFF
--- a/filterapply.go
+++ b/filterapply.go
@@ -59,6 +59,8 @@ func apply(statement squirrel.SelectBuilder, f yaormfilter.Filter, dbp DBProvide
 			if dbp.CanSelectForUpdate() {
 				statement = statement.Suffix(fmt.Sprintf(`FOR UPDATE OF %s`, dbp.EscapeValue(applier.tableName)))
 			}
+		case yaormfilter.RequestOptions.SelectDistinct:
+			statement = statement.Distinct()
 		}
 	}
 	for _, orderBy := range f.GetOrderBy() {

--- a/testdata/post.go
+++ b/testdata/post.go
@@ -40,6 +40,15 @@ func NewPostFilter() *PostFilter {
 	return &PostFilter{}
 }
 
+func (f *PostFilter) AddOption(opt yaormfilter.RequestOption) yaormfilter.Filter {
+	f.AddOption_(opt)
+	return f
+}
+
+func (f *PostFilter) Distinct() {
+	f.AddOption("SelectDistinct")
+}
+
 func (f *PostFilter) ID(v yaormfilter.ValueFilter) *PostFilter {
 	f.FilterID = v
 	return f

--- a/yaormfilter/filter.go
+++ b/yaormfilter/filter.go
@@ -38,9 +38,11 @@ type RequestOption string
 // RequestOptions represents the Enum of Request options
 var RequestOptions = struct {
 	SelectForUpdate RequestOption
+	SelectDistinct  RequestOption
 	LeftJoin        RequestOption
 }{
 	SelectForUpdate: "SelectForUpdate",
+	SelectDistinct:  "SelectDistinct",
 	LeftJoin:        "LeftJoin",
 }
 
@@ -103,7 +105,7 @@ func (mf *ModelFilter) GetSelectOptions() []RequestOption {
 	opts := []RequestOption{}
 	for _, opt := range mf.options {
 		switch opt {
-		case RequestOptions.SelectForUpdate:
+		case RequestOptions.SelectForUpdate, RequestOptions.SelectDistinct:
 			opts = append(opts, opt)
 		}
 	}


### PR DESCRIPTION
squirell has the ability to add a DISTINCT clause to a SQL statement, but we have no way to use it from yaorm.

This PR adds a RequestOptions for SELECT DISTINCT in filter.go