### PR TITLE
fix(intervalstyle): Exec function does not replace placeholders in such cases

### DIFF
--- a/dbprovider_test.go
+++ b/dbprovider_test.go
@@ -118,8 +118,8 @@ func TestDBProvider_Postgres_OnSessionCreated(t *testing.T) {
 	assert.Len(t, exec.queries, 1)
 	assert.True(t, reflect.DeepEqual(exec.queries, []logParams{
 		{
-			query: "SET intervalstyle = ?",
-			args:  []interface{}{"iso_8601"},
+			query: "SET intervalstyle = 'iso_8601'",
+			args:  []interface{}{},
 		},
 	}))
 	_, err = dbp.DB().Exec("SELECT 1")
@@ -127,8 +127,8 @@ func TestDBProvider_Postgres_OnSessionCreated(t *testing.T) {
 	assert.Len(t, exec.queries, 2)
 	assert.True(t, reflect.DeepEqual(exec.queries, []logParams{
 		{
-			query: "SET intervalstyle = ?",
-			args:  []interface{}{"iso_8601"},
+			query: "SET intervalstyle = 'iso_8601'",
+			args:  []interface{}{},
 		},
 		{
 			query: "SELECT 1",

--- a/dbspecific_postgres.go
+++ b/dbspecific_postgres.go
@@ -1,5 +1,7 @@
 package yaorm
 
+import "fmt"
+
 // PostgresSpecific holds specific configurations used by Postgres
 type PostgresSpecific struct {
 	// IntervaStyle holds the style of output of the interval
@@ -12,7 +14,8 @@ type PostgresSpecific struct {
 // - IntervalStyle
 func (p PostgresSpecific) OnSessionCreated(dbp DBProvider) error {
 	if p.IntervalStyle != "" {
-		if _, err := dbp.DB().Exec("SET intervalstyle = ?", p.IntervalStyle); err != nil {
+		// Exec does not take the "?" or "$1" placeholdes into account in such queries
+		if _, err := dbp.DB().Exec(fmt.Sprintf("SET intervalstyle = '%s'", p.IntervalStyle)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This will avoid having syntax errors due to the non-replacement of placeholders 